### PR TITLE
add dependencies in the .app.src file

### DIFF
--- a/src/influx_udp.app.src
+++ b/src/influx_udp.app.src
@@ -5,7 +5,10 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  lager,
+                  ulitos,
+                  poolboy
                  ]},
   {mod, { influx_udp_app, []}},
   {env, []}


### PR DESCRIPTION
Trying to make a release with influx_udp breaks, because its application dependencies are not specified in the `influx_udp.app` file. After this change, I'm able to run a release that includes influx_udp.