### PR TITLE
Don't depend on lager for logging

### DIFF
--- a/include/influx_udp_priv.hrl
+++ b/include/influx_udp_priv.hrl
@@ -4,16 +4,38 @@
 
 %% log functions
 
+-ifdef(OLD_LOGGER).
+
 -ifdef(TEST).
 
--define(D(X), lager:info("[DEBUG] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
--define(I(X), lager:info("[INFO] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
--define(E(X), lager:info("[ERROR] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
+-define(D(X), error_logger:info_msg("[DEBUG] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
+-define(I(X), error_logger:info_msg("[INFO] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
+-define(E(X), error_logger:info_msg("[ERROR] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
 
 -else.
 
--define(D(X), lager:debug("~p:~p ~p",[?MODULE, ?LINE, X])).
--define(I(X), lager:info("~p:~p ~p",[?MODULE, ?LINE, X])).
--define(E(X), lager:error("~p:~p ~p",[?MODULE, ?LINE, X])).
+-define(D(X), begin _ = X end).
+-define(I(X), error_logger:info_msg("~p:~p ~p",[?MODULE, ?LINE, X])).
+-define(E(X), error_logger:error_msg("~p:~p ~p",[?MODULE, ?LINE, X])).
+
+-endif.
+
+-else. % Use Erlang/OTP 21+ Logger.
+
+-include_lib("kernel/include/logger.hrl").
+
+-ifdef(TEST).
+
+-define(D(X), ?LOG_INFO("[DEBUG] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
+-define(I(X), ?LOG_INFO("[INFO] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
+-define(E(X), ?LOG_INFO("[ERROR] ~p:~p ~p~n",[?MODULE, ?LINE, X])).
+
+-else.
+
+-define(D(X), ?LOG_DEBUG(X)).
+-define(I(X), ?LOG_INFO(X)).
+-define(E(X), ?LOG_ERROR(X)).
+
+-endif.
 
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,6 @@
 
 {require_otp_vsn, "18"}.
 {deps, [
-  lager,
   ulitos,
   poolboy
 ]}.
@@ -20,7 +19,7 @@
 
 {plugins, [rebar3_hex]}.
 
-{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+{erl_opts, [debug_info, {platform_define, "^(18|19|20)\.", 'OLD_LOGGER'}]}.
 
 {cover_enabled, true}.
 
@@ -29,6 +28,6 @@
   {report, {eunit_progress, [colored, profile]}}
 ]}.
 
-{shell, [{config, "files/app.config"}, {apps, [lager, ulitos, poolboy, influx_udp]}]}.
+{shell, [{config, "files/app.config"}, {apps, [ulitos, poolboy, influx_udp]}]}.
 
 {clean_files, ["*.eunit", "ebin/*.beam"]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,12 +1,10 @@
 {"1.1.0",
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.7.0">>},0},
  {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.2">>},0},
  {<<"ulitos">>,{pkg,<<"ulitos">>,<<"0.4.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"563AB17CD32134A3DD17EC3B3622E6D8F827506AA4F8C489158879BED87D980B">>},
  {<<"poolboy">>, <<"392B007A1693A64540CEAD79830443ABF5762F5D30CF50BC95CB2C1AAAFA006B">>},
  {<<"ulitos">>, <<"BCDF0528AF4B59F1CB7D710E4B056688751C600833F31F504FEC4BAA88F0F42B">>}]}
 ].

--- a/src/influx_udp.app.src
+++ b/src/influx_udp.app.src
@@ -3,7 +3,7 @@
     {description, "InfluxDB UDP writer"},
     {vsn, "1.0.0"},
     {registered, []},
-    {applications, [kernel, stdlib, lager, ulitos, poolboy]},
+    {applications, [kernel, stdlib, ulitos, poolboy]},
     {mod, { influx_udp_app, []}},
     {env, []},
     {maintainers, ["Vladimir Dementyev"]},

--- a/src/influx_udp.erl
+++ b/src/influx_udp.erl
@@ -2,7 +2,7 @@
 -include_lib("influx_udp/include/influx_udp_priv.hrl").
 -include_lib("influx_udp/include/influx_udp.hrl").
 -define(SERVER, ?MODULE).
--define(DEPS, [lager, ulitos, poolboy]).
+-define(DEPS, [ulitos, poolboy]).
 
 %% ------------------------------------------------------------------
 %% API Function Exports


### PR DESCRIPTION
Use the standard [Logger][1] on Erlang/OTP 21+, and the standard [error logger][2] on older OTP versions.  The problem with lager is that it [messes][3] with the standard Logger, which I think shouldn't be done from library applications, as that can easily break the main application's logging setup.  (Also, lager pulls in quite a few dependencies, which seems a bit excessive just for talking UDP to InfluxDB.)

Note that with this PR, debug logging will require Erlang/OTP 21+.  Also, on 21+, `Module:Line` information is no longer included with log messages, as such things should be [left][4] to the main application as well, IMO.

Many thanks to @pvJ2FLc2 for testing this PR.

[1]: https://erlang.org/doc/apps/kernel/logger_chapter.html
[2]: https://erlang.org/doc/man/error_logger.html
[3]: https://github.com/erlang-lager/lager/blob/d88b3663b9e6d5313207b30869deb160ffd503ec/src/lager_app.erl#L186-L191
[4]: https://erlang.org/doc/apps/kernel/logger_chapter.html#formatters