### PR TITLE
rebar.config: Include debug info by default

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 
 {profiles, [
   {prod, [
-    {erl_opts, [no_debug_info, warn_unused_vars, warnings_as_errors]}
+    {erl_opts, [warn_unused_vars, warnings_as_errors]}
   ]},
   {test, [
     {deps, [eunit_formatters]},


### PR DESCRIPTION
Currently, there [seems to be no way][1] for the main application to override [the `no_debug_info` option][2] using rebar3, so commands such as `rebar3 dialyzer` fail when influx_udp is used.

Therefore, leave stripping of BEAM files to the main application (e.g., by specifying the Relx option `{debug_info, strip}`, as [suggested][3] by one of the rebar3/Relx maintainers).

[1]: https://github.com/erlang/rebar3/issues/2324
[2]: https://github.com/palkan/influx_udp/blob/1353d3d9937c840d9f1bcae0b89d129b3ba372a9/rebar.config#L12
[3]: https://github.com/erlang/rebar3/issues/2324#issuecomment-674142215