### PR TITLE
Fix GitHub Actions CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
             rebar: '3.17.0'
           - otp: '23.1'
             rebar: '3.17.0'
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2.0.0
       - uses: ErlGang/setup-erlang@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
       - uses: ErlGang/setup-erlang@master
         with:
           otp-version: ${{matrix.otp}}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/rebar3
+          key: ${{runner.os}}-${{matrix.otp}}-${{hashFiles('rebar.config')}}
       - run: curl -LO https://github.com/erlang/rebar3/releases/download/${{matrix.rebar}}/rebar3
       - run: chmod +x rebar3
       - run: ./rebar3 do compile, dialyzer, eunit, ct

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         otp: [20.3, 21.3, 22.1, 23.1]
     steps:
       - uses: actions/checkout@v2.0.0
-      - uses: gleam-lang/setup-erlang@v1.1.3
+      - uses: ErlGang/setup-erlang@master
         with:
           otp-version: ${{matrix.otp}}
       - run: rebar3 do compile, dialyzer, eunit, ct

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,20 @@ jobs:
     strategy:
       matrix:
         otp: [20.3, 21.3, 22.1, 23.1]
+        include:
+          - otp: '20.3'
+            rebar: '3.15.2'
+          - otp: '21.3'
+            rebar: '3.15.2'
+          - otp: '22.1'
+            rebar: '3.17.0'
+          - otp: '23.1'
+            rebar: '3.17.0'
     steps:
       - uses: actions/checkout@v2.0.0
       - uses: ErlGang/setup-erlang@master
         with:
           otp-version: ${{matrix.otp}}
-      - run: rebar3 do compile, dialyzer, eunit, ct
+      - run: curl -LO https://github.com/erlang/rebar3/releases/download/${{matrix.rebar}}/rebar3
+      - run: chmod +x rebar3
+      - run: ./rebar3 do compile, dialyzer, eunit, ct


### PR DESCRIPTION
Fix CI tests by:

1. Using [ErlGang/setup-erlang][1] instead of [gleam-lang/setup-erlang][2], as the latter currently seems to fail, and
2. downloading rebar3 manually, as the preinstalled version isn't compatible with Erlang/OTP < 22.

While at it, also make sure a build isn't aborted just because another build fails (as that made it harder to spot problems which only affect some of the tested OTP versions), and cache rebar3 data.

[1]: https://github.com/ErlGang/setup-erlang
[2]: https://github.com/gleam-lang/setup-erlang